### PR TITLE
Fixed Poketes not being freeable

### DIFF
--- a/pokete_classes/deck.py
+++ b/pokete_classes/deck.py
@@ -3,11 +3,11 @@
 import scrap_engine as se
 from pokete_classes import detail
 import pokete_classes.game_map as gm
+import pokete_classes.movemap as mvp
 from .event import _ev
 from .input import ask_bool
 from .loops import std_loop
 from .color import Color
-from .movemap import movemap
 from .poke import Poke
 from .ui_elements import StdFrame2
 
@@ -110,7 +110,7 @@ class Deck(detail.Informer):
                         + len(pokes[self.index.index].text_name.text)
                         + 1,
                         pokes[self.index.index].text_name.y)
-                    movemap.balls_label_rechar(self.figure.pokes)
+                    mvp.movemap.balls_label_rechar(self.figure.pokes)
             elif _ev.get() in ["'w'", "'a'", "'s'", "'d'"]:
                 self.control(pokes, _ev.get())
                 _ev.clear()


### PR DESCRIPTION
Global import for initialized modules has to be used, so initialization isn't lost.