### PR TITLE
FIX: Shiny status gets lost when pokete evolves

### DIFF
--- a/pokete_classes/poke.py
+++ b/pokete_classes/poke.py
@@ -239,7 +239,7 @@ can't have more than 4 attacks!"
                 or self.lvl() < self.evolve_lvl:
             return False
         evomap = EvoMap(_map.height, _map.width)
-        new = Poke(self.evolve_poke, self.xp, _attacks=self.attacks)
+        new = Poke(self.evolve_poke, self.xp, _attacks=self.attacks, shiny=self.shiny)
         self.ico.remove()
         self.ico.add(evomap, round(evomap.width / 2 - 4),
                      round((evomap.height - 8) / 2))


### PR DESCRIPTION
Hi! I'm not a python dev, so this might be completely wrong. I tried to guess the logic by seeing that the `_attacks` argument was used while skipping the fill of the hp status and it sounds like it works, so I added the shiny status from the current pokete instance to be kept in the evolved pokete one.

Closes #163 

Hope I am right and you appreciate the solution 🙌 