### PR TITLE
Fix English mistakes in Markdown files

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -1,5 +1,5 @@
 # Development guide for Pokete
-This guide only handles adding new types, attacks and Poketes to Pokete, for further information on class and function syntax see the html documentation or `$ pydoc <file>`.
+This guide only handles adding new types, attacks and Poketes to Pokete. For further information on class and function syntax, see the HTML documentation or `$ pydoc <file>`.
 
 1. [Adding Poketes](#adding-poketes)
 2. [Adding attacks](#adding-attacks)
@@ -7,25 +7,25 @@ This guide only handles adding new types, attacks and Poketes to Pokete, for fur
 4. [Adding subtypes](#adding-subtypes)
 
 ## Adding Poketes
-Every Pokete has an entry the `pokes` dictionary in [`pokete_data/poketes.py`](./pokete_data/poketes.py) every entry needs to have this structure:
+Every Pokete has an entry in the `pokes` dictionary in [`pokete_data/poketes.py`](./pokete_data/poketes.py). Every entry needs to have this structure:
 
 ```Python
-"steini": {  # This is the Poketes simplified name/identifier without spaces and in lowercase, which is used to refer to the Pokete in the game
-        "name": "Steini",  # This is the Poketes actual pretty name
-        "hp": 25,  # The Poketes max health points
-        "atc": 2,  # The Poketes attack points that will added to the Poketes level
-        "defense": 4,  # The Poketes defense points that will added to the Poketes level
-        "attacks": ["tackle", "politure", "brick_throw"],  # The Poketes starting attacks
+"steini": {  # This is the Poketes simplified name/identifier without spaces and in lowercase, which is used to refer to the Pokete in the code
+        "name": "Steini",  # This is the Pokete's pretty name
+        "hp": 25,  # The Pokete's max health points
+        "atc": 2,  # The Pokete's attack points that will added to the Pokete's level
+        "defense": 4,  # The Pokete's defense points that will added to the Pokete's level
+        "attacks": ["tackle", "politure", "brick_throw"],  # The Pokete's starting attacks
         "pool": [],  # List of additional ungeneric attacks the Pokete can learn
         "miss_chance": 0,  # The chance a Pokete will miss an attack, this is added to the attacks individual `miss_chance`
-        "desc": "A squared stone that can casually be found on the ground.",  # The Poketes description
-        "lose_xp": 3,  # The amount of experience the player gets killing the Pokete
+        "desc": "A squared stone that can casually be found on the ground.",  # The Pokete's description
+        "lose_xp": 3,  # The amount of experience the player gets by killing the Pokete
         "rarity": 1,  # Rarity
-        "types": ["stone", "normal"],  # The Poketes types
-        "evolve_poke": "",  # The name/identifier of the Pokete this Pokete evolves to at a certain level
+        "types": ["stone", "normal"],  # The Pokete's types
+        "evolve_poke": "",  # The name/identifier of the Pokete, that this Pokete evolves to at a certain level
         "evolve_lvl": 0,  # The level the Pokete evolves at
-        "initiative": 5,  # The Poketes initiative points that will added to the Poketes level, and determine what Pokete starts in a fight
-        "ico": [{  # A list of dictionaries containing a displayed string and a color, all those strings will be layered over each other and represent the Pokete in the fight
+        "initiative": 5,  # The Pokete's initiative points that will added to the Pokete's level, and determine what Pokete starts in a fight
+        "ico": [{  # A list of dictionaries containing a displayed string and a color; all those strings will be layered over each other and represent the Pokete in the fight
             "txt": """ +-------+
  | o   o |
  |  www  |
@@ -37,7 +37,7 @@ Every Pokete has an entry the `pokes` dictionary in [`pokete_data/poketes.py`](.
 For more examples on the dictionaries see [`pokete_data/poketes.py`](./pokete_data/poketes.py).
 
 ### Types
-Only the first type in the `"types"` list is the Poketes actual displayed type, that determines the Poketes effectivity. The other types in the list are just secondary types that determine what generic attacks a Pokete is able to learn. Those can also be subtypes. The main type can't!
+Only the first type in the `"types"` list is the Poketes actual displayed type that determines the Pokete's effectivity. The other types in the list are just secondary types that determine what generic attacks a Pokete is able to learn. Those can also be subtypes. The main type can't!
 For a list of all types and subtypes see [`pokete_data/types.py`](./pokete_data/types.py)
 
 ### Learning attacks
@@ -45,47 +45,47 @@ In addition the attacks in the `"attacks"` and the `"pool"` lists, a Pokete can 
 
 
 ## Adding attacks
-Every attack has an entry the `attacks` dictionary in [`pokete_data/attacks.py `](./pokete_data/attacks.py) every entry needs to have this structure:
+Every attack has an entry in the `attacks` dictionary in [`pokete_data/attacks.py `](./pokete_data/attacks.py). Every entry needs to have this structure:
 
 ```Python
-"poison_bite": {  # This is the attacks simplified name/identifier without spaces and in lowercase, which is used to refer to the attack in the game
-        "name": "Poison bite",  # The attacks displayed name
-        "factor": 1,  # The attack factor, that is used to calculate damage
-        "action": "",  # A String that's executed when the attack is used, to effect the Poketes or the enemies values (don't use this) 
+"poison_bite": {  # This is the attack's simplified name/identifier without spaces and in lowercase, which is used to refer to the attack in the code
+        "name": "Poison bite",  # The attack's pretty name
+        "factor": 1,  # The attack factor that is used to calculate damage
+        "action": "",  # A string that's executed when the attack is used, to effect the Pokete's or the enemy's values (don't use this) 
         "world_action": "",  # An extra ability the attack can be used for
         "move": ["attack", "downgrade"],  # The moves the Pokete does using the attack
         "miss_chance": 0.3,  # The chance to miss the attack
-        "min_lvl": 0,  # The minimal level a Poketes has to have to learn the attack
-        "desc": "Makes the enemy weaker.",  # The attacks description
-        "types": ["poison"],  # The attacks types
+        "min_lvl": 0,  # The minimal level a Pokete needs in order to learn the attack
+        "desc": "Makes the enemy weaker.",  # The attack's description
+        "types": ["poison"],  # The attack's types
         "effect": "poison",  # The effect the enemy gets when the attack is used, default is None 
         "is_generic": False,  # Whether or not the attack can be learned by any Pokete of its types
-        "ap": 10,  # The attack points the attack has, so the amount of times the attack can be used by a Pokete until the Pokete has to be healed
+        "ap": 10,  # Attack points; the amount of times the attack can be used by a Pokete until the Pokete has to be healed
     },
 ```
 
 For more examples on the dictionaries see [`pokete_data/attacks.py`](./pokete_data/attacks.py).
 
 ### Types and learning
-Only the first type in the `"types"` list is the attacks real type and determines its effectivity. The other type can only be subtypes. A generic attack can only be learned by a Poketes that has all its types. An ungeneric attack can only be learned if the attack is in the Poketes `"pool"` or `"attacks"` list.
+Only the first type in the `"types"` list is the attack's real type and determines its effectivity. The other type can only be subtypes. A generic attack can only be learned by a Pokete that has all its types. An ungeneric attack can only be learned if the attack is in the Pokete's `"pool"` or `"attacks"` list.
 
 ### Effects
 The effect given in the `"effect"` attribute has to be the `c_name` of an effect listed in [`pokete_classes/types.py`](./pokete_classes/types.py ) or `None`.
 
 ### World action
-An attacks `"world_action"` is some kind of extra ability which can be called from the Poketes detail view and be used to, for example make the player fly. The string in `"world_action"` has to be a key in the `abb_funcs` list in [`pokete.py`](./pokete.py).
+An attacks `"world_action"` is some kind of extra ability which can be called from the Poketes detail view and be used to, for example, make the player fly. The string in `"world_action"` has to be a key in the `abb_funcs` list in [`pokete.py`](./pokete.py).
 
 
 ## Adding types
-Every type has an entry the `types` dictionary in [`pokete_data/types.py`](./pokete_data/types.py) every entry needs to have this structure:
+Every type has an entry inside the `types` dictionary in [`pokete_data/types.py`](./pokete_data/types.py). Every entry needs to have this structure:
 
 ```Python
-"stone": {  # The types name
+"stone": {  # The type's name
         "effective": ["flying", "fire"],  # The types the type is effective against 
         "ineffective": ["plant"],  # The types the type is ineffective against
-        "color": ["grey"]  # The types label color
+        "color": ["grey"]  # The type's label color
     },
 ```
 
 ## Adding subtypes
-Every subtype has an entry the `sub_types` list in [`pokete_data/types.py`](./pokete_data/types.py). They have no further attributes. Subtypes are only useful to determine what Poketes can which generic attack in a type. For example to avoid that `bato` learns the generic `flying` attack `pick`.
+Every subtype has an entry inside the `sub_types` list in [`pokete_data/types.py`](./pokete_data/types.py). They have no further attributes. Subtypes are only useful to determine what Poketes can use what generic attack in a type. For example, to avoid that `bato` learns the generic `flying` attack `pick`.

--- a/HowToPlay.md
+++ b/HowToPlay.md
@@ -19,12 +19,12 @@
 
 
 ## Plot
-The plot of the game is that you--a ten year old boy/girl/whatever--are running around in the world doing what ten years olds do: catching little creatures (Poketes) and letting them fight against other little creatures.
+The plot of the game is that you - a ten year old boy/girl - are running around in the world doing what ten year olds do; catching little creatures (Poketes) and letting them fight against other little creatures.
 
 You are on a journey to explore the world and catch all Poketes. Along the way you will meet many different NPCs that may or may not be nice to you.
 
 ## Controls
-After first starting the game you can move the character, the one little `a` on the screen using `w`, `a`, `s` and `d`.
+After first starting the game you can move the character, the one little `a` on the screen, using `w`, `a`, `s` and `d`.
 
 ![Map](assets/ss/ss08.png)
 
@@ -32,7 +32,7 @@ You can open the settings/menu by pressing `e`.
 
 ![Menu](assets/ss/ss07.png)
 
-In this type of menu you can navigate using `w` and `s` to move the cursor and `enter` to select the option. To exit just press `Esc` or `q`.
+In this type of menu you can navigate using `w` and `s` to move the cursor and `Enter` to select the option. To exit just press `Esc` or `q`.
 
 ## Fights
 
@@ -42,9 +42,9 @@ When going onto the green grass patch you may get attacked by a wild Pokete.
 
 ![Grass](assets/ss/ss10.png)
 
-Now you have several options to choose from, you can attack and weaken the Pokete to catch it, run away, or choose another Pokete.
+Now you have several options to choose from; you can attack and weaken the Pokete to catch it, run away, or choose another Pokete.
 
-To attack, just press `1` and a little selection window opens where you can choose from your attacks. You can ether navigate the cursor to the attack you want to choose (using `w` and `s`) and then press `enter`, or you just type in the number before the attack name.
+To attack, just press `1` and a little selection window opens where you can choose from your attacks. You can either navigate the cursor to the attack you want to choose (using `w` and `s`) and then press `Enter`, or you can just type in the number before the attack name.
 
 The Number behind the name are the AP (Attack Points) of the attack (The number of times you can use the attack and the number of uses you have remaining).
 
@@ -54,32 +54,32 @@ When you fight until the enemy Pokete's HP is low (like 1 to 3 HP), you can try 
 
 ![Catching](assets/ss/ss12.png)
 
-Catching a Pokete may not be successful on the first try.
+Catching a Pokete may not be successful at first.
 You can also kill the Pokete and gain XP for your Pokete.
 
 ## Trainers
-Trainers are other ten years old Pokete trainers just like you. They are the other `a`s you may encounter on the map. They will talk to you and then start a fight; the only difference between a trainer fight and a normal fight is that you cannot run away from a trainer fight and cannot catch the enemys' Pokete. They will give you $20 if you win.
+Trainers are other ten year old Pokete trainers just like you. They are the other `a`s you may encounter on the map. They will talk to you and then start a fight. The only difference between a trainer fight and a normal fight is that you cannot run away from a trainer fight and cannot catch the enemy's Pokete. They will give you $20 if you win.
 
 ## Inventory
-By Pressing `4` you can open your inventory. This is  where you can see all of your items, their amounts, and how much money you have. By selecting an item with the cursor and pressing `enter` you can see the item's description. To exit, just press `Esc` or `q`.
+By pressing `4`, you can open your inventory. This is where you can see all of your items, and how much money you have. By selecting an item with the cursor and pressing `Enter` you can see the item's description. To exit, just press `Esc` or `q`.
 
 ![Inv](assets/ss/ss18.png)
 
-By having an item selected and pressing `r` you can remove it from your inventory.
+By having an item selected and pressing `r`, you can remove it from your inventory.
 
 ## Minimap
-By pressing `3` you can open a map of the complete Pokete world where you can see and select all Routes/Towns on the map. You can select and navigate by using `w`, `a`, `s` and `d`. To exit just press `Esc` or `q`.
+By pressing `3`, you can open a map of the Pokete world where you can see and select all Routes and Towns on the map. You can select and navigate by using `w`, `a`, `s` and `d`. To exit, just press `Esc` or `q`.
 
 ![Map](assets/ss/ss19.png)
 
-## Pokete centers
-On your journey through the Pokete world you may discover the some houses. 
+## Pokete Centers
+On your journey through the Pokete world you may discover some houses. 
 
-Some of those houses are Pokete centers where you can heal your wounded Poketes and reorganize your deck.
+Some of these houses are Pokete Centers where you can heal your wounded Poketes and reorganize your deck.
 
 ![Center](assets/ss/ss13.png)
 
-By going up to the person behind the counter you can interact with them. 
+By going up to the person behind the counter you can interact with them.
 
 ![Center](assets/ss/ss14.png)
 
@@ -92,52 +92,52 @@ By going up to the person behind the counter you can interact with them.
 
 ![Shop](assets/ss/ss16.png)
 
-To by an item just navigate the cursor to it and press `enter`. The item will then be added to your inventory. To exit just press `Esc` or `q`.
+To buy an item, just navigate the cursor to it and press `Enter`. The item will then be added to your inventory. To exit, just press `Esc` or `q`.
 
 ## Poketeballs
-Poketeballs are needed to catch Poketes. You can see how many Poketeballs you have in your Inventory, buy them in the [Pokete shop](#pokete-shops) and find them on the map.
+Poketeballs are needed to catch Poketes. You can see how many Poketeballs you have in your inventory, buy them from the [Pokete Shop](#pokete-shops) and find them on the map.
 They are the small red balls hidden all over the map, and can be collected by just walking over them.
 
 ![Balls](assets/ss/ss17.png)
 
 ## Settings
-In the game's menu/settings you can change the players name, save, exit, or change other settings. To exit just press `Esc` or `q`.
+In the game's settings you can change the player's name, save your game, exit, or change other settings. To exit, just press `Esc` or `q`.
 
 ![Settings](assets/ss/ss20.png)
 
 ## Trading
-When you're in the same network as another Pokete-player you can trade one of your Poketes for one of theirs.
-In the Pokete-center stands another NPC, the trader, who you can talk to and start the trade.
+When you're in the same network as another Pokete player you can trade one of your Poketes for one of theirs.
+In the Pokete Center stands another NPC, the trader, who you can talk to and start a trade.
 
 ![trading](assets/ss/ss21.png)
 
-One of the two players must be the host while the other is the guest. The host has to start the trade first for it to work.
+One of the two players must be the host, while the other is the guest. The host has to start the trade first for it to work.
 
 ![trading](assets/ss/ss22.png)
 
-When prompted, the guest must type in the hostname of the host's computer displayed on the host's display.  
+When prompted, the guest must type in the hostname of the host's computer displayed on the host's display.
 You may run into problems with firewalls.
 
 ![trading](assets/ss/ss23.png)
 
 ## Shiny Poketes
-Shiny Poketes are rare to find (chance 1/500) and have 2 points more of attack, defense, and initiative as well as 5 HP more than normal. Their names are highlighted yellow. 
+Shiny Poketes are rare to find (chance 1/500) and have 2 points more of attack, defense, and initiative as well as 5 HP more than normal Poketes. Their names are highlighted yellow. 
 
 ![shiny](assets/ss/ss24.png)
 
-## Pokete-dex
-The Pokete dex is made for the user to keep track of all Poketes they ever caught along with their stats. It does not list individual Poketes, but instead the Pokete 'race' itself. Poketes your never caught are shown with a "???".
+## Poketedex
+The Poketedex is made for the player to keep track of all Poketes they have ever caught, along with their stats. It does not list individual Poketes, but instead the Pokete 'race' itself. Poketes you haven't caught yet are shown as a "???".
 
-It can be accessed by pressing 5 in the main game.
+The Poketedex can be accessed by pressing `5` in the main game.
 
 ![dex](assets/ss/ss25.png)
 
 ## Learning Attacks
-Every fifth level, a Pokete will try to learn a new attack. If the number of attacks a Pokete has is already four, the player will be prompted to choose which attack will be replaced by the new one, otherwise it will just be added to the existing attacks.
+For every fifth time a Pokete levels up, it will try to learn a new attack. If the Pokete already has the maximum amount of attacks (4), the player will be prompted to choose an attack to be replaced with the new one. If the amount of attacks is under 4, the new attack will just be added to the existing attacks.
 
 ![learning](assets/ss/ss26.png)
 
 ![learning](assets/ss/ss27.png)
 
-## Learning-Discs
-LDs are DVD-like items you can find on the map which can be used to teach a special attack to a Pokete. They can only be used once!
+## Learning Discs
+Learning Discs are DVD-like items you can find on the map which can be used to teach a special attack to a Pokete. They can only be used once!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-2[![Wiki](https://github.com/lxgr-linux/pokete/actions/workflows/main.yml/badge.svg)](https://github.com/lxgr-linux/pokete/actions/workflows/main.yml)
+[![Wiki](https://github.com/lxgr-linux/pokete/actions/workflows/main.yml/badge.svg)](https://github.com/lxgr-linux/pokete/actions/workflows/main.yml)
 [![Code-Validation](https://github.com/lxgr-linux/pokete/actions/workflows/main_validate.yml/badge.svg)](https://github.com/lxgr-linux/pokete/actions/workflows/main_validate.yml)
 [![GitHub-Pages Build](https://github.com/lxgr-linux/pokete/actions/workflows/documentation.yml/badge.svg)](https://github.com/lxgr-linux/pokete/actions/workflows/documentation.yml)
 <br>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Wiki](https://github.com/lxgr-linux/pokete/actions/workflows/main.yml/badge.svg)](https://github.com/lxgr-linux/pokete/actions/workflows/main.yml)
+2[![Wiki](https://github.com/lxgr-linux/pokete/actions/workflows/main.yml/badge.svg)](https://github.com/lxgr-linux/pokete/actions/workflows/main.yml)
 [![Code-Validation](https://github.com/lxgr-linux/pokete/actions/workflows/main_validate.yml/badge.svg)](https://github.com/lxgr-linux/pokete/actions/workflows/main_validate.yml)
 [![GitHub-Pages Build](https://github.com/lxgr-linux/pokete/actions/workflows/documentation.yml/badge.svg)](https://github.com/lxgr-linux/pokete/actions/workflows/documentation.yml)
 <br>
@@ -22,7 +22,7 @@
 Pokete is a small terminal based game in the style of a very popular and old game by Gamefreak.
 
 ## Installation
-For Linux just do this:
+For Linux, run this:
 ```shell
 # pip install scrap_engine playsound pygobject
 $ git clone https://github.com/lxgr-linux/pokete.git
@@ -38,7 +38,7 @@ Or you can just run the AppImage from the release page.
 
 NOTE: In that case you first have to create the `~/.cache/pokete/` folder.
 
-For Windows and OSX:
+For Windows and OS X:
 
 ```shell
 git clone https://github.com/lxgr-linux/pokete.git
@@ -47,27 +47,27 @@ pip install scrap_engine pynput playsound pygobject
 To run just execute `pokete.py`.
 
 ## Usage
-The game can be run normaly by not supplying any options.
-For non gameplay related usage see `--help`.
+The game can be run normally without supplying any options.
+For non gameplay related usage, use `--help`.
 Try it out [online](https://replit.com/@lxgr-linux/pokete).
 
-## How to play?
-Imagine you're a Pokete-Trainer and you run around in the world to catch/train as many Poketes as possible with the ultimate goal of becoming the best trainer.
+## How to play
+Imagine that you're a Pokete Trainer and you travel around the world to catch/train as many Poketes as possible with the ultimate goal of becoming the best trainer.
 
 First of all you get a starter Pokete (Steini), that you can use to fight battles with other Poketes.
-The controls are w a s d to walk around.
+Use W, A, S and D to move around.
 
-When entering the high grass (;), you may be attacked by a wild Pokete. By pressing 1 you can choose between the attacks (as long their AP is over 0) your Pokete has, and by pressing the according number, or navigating with the "\*"-cursor to the attack and pressing enter. The wild Pokete will fight back but you can kill it and gain XP to level up your Pokete. If you would like to catch the wild Pokete, you must first weaken it and then throw a Poketeball. With a bit of luck, you can catch it and have it fight for you.
+When entering the high grass (;), you may be attacked by a wild Pokete. By pressing `1` you can choose between the attacks your Pokete has (as long their AP is over 0). By pressing the according number, or navigating with the `*` cursor to the attack and pressing `Enter` you can use the attack selected. The wild Pokete will fight back, but you can kill it and gain XP to level up your Pokete. If you would like to catch a wild Pokete, you must first weaken it and then throw a Poketeball. With a bit of luck, you can catch it and have it fight for you.
 
-Pressing the "1" key you can take a look at your current deck, see the detailed information of your Pokete and your attacks or rearrange them.
+By pressing the `1` key, you can take a look at your current deck. You can see detailed information of your Pokete and your attacks, or rearrange them.
 Changes will only be saved by quitting the game using the exit function.
 
-Since you're a Pokete-Trainer, you can also fight against other trainers (the  other "a" in the middle of the landscape). He will start a fight with you when you get close enough to him. You can not escape from such a trainer fight, you either have to win, or lose. These trainer fights give double the XP.
+Since you're a Pokete Trainer, you can also fight against other trainers (they appear as an 'a'). He will start a fight with you when you get close enough to him. You can not run from a trainer fight; you either have to win, or lose. These trainer fights give double the XP.
 
-When one of your Poketes die, or is too weak, you can heal it by going into the house (Pokete-Center), talk the the person there and choose the healing option.
-Here you can also take a look at all of your Poketes, and not just the six in your team. The ones marked with an "o" are the ones in your deck.
+When one of your Poketes is too weak or dies, you can heal it by going into the Pokete Center (the house), talk the the person there and choose the healing option.
+Here you can also take a look at all of your Poketes, and not just the six in your team. The ones marked with an `o` are the ones in your deck.
 
-By pressing "e" you can get into a menu where player name, and later other settings, can be changed.
+By pressing `e`, a menu will appear where player name, and later other settings, can be changed.
 
 The red balls all over the map are Poketeballs. You'll need these to catch Poketes. Stepping on such a ball will add it to your inventory.
 
@@ -97,29 +97,28 @@ Mods can be written to extend Pokete. To load a mod, the mod has to be placed in
 For an example mod see [example.py](mods/example.py).
 
 ## Tips
-- In conversations you can very easily skip the text printing by pressing any key
-- When you want to see the next text in a conversation: press any key
+- When you want to see the next part of a conversation, press any key
 - Don't play on full-screen; the game will not run properly
 - Don't be offended by the other trainers; they may swear at you
 
 ## TODO
-- [x] Add a wizard to set name and choose starter Pokete at the start
-- [ ] Add More maps
-- [x] Add types for attacks and Poketes
-- [x] Add evolving
-- [ ] Add more than one Pokete for trainers
+- [x] A wizard at the start to set name and starter Pokete
+- [ ] More maps
+- [x] Types for attacks and Poketes
+- [x] Evolving
+- [ ] More than one Pokete for trainers
 - [x] Coloured Poketes
 - [x] A store to buy Poketeballs
-- [x] Add potions
-- [x] Add Intro
-- [x] Add trading
-- [x] Add Poketedex
+- [x] Potions
+- [x] Intro
+- [x] Trading
+- [x] Poketedex
 - [x] Effects
-- [x] Add colour codes for types
+- [x] Colour codes for types
 
 ## Dependencies
-Pokete depends on python3 and the scrap_engine module.
-On windows pynput has to be installed too.
+Pokete depends on python3 and the `scrap_engine` module.
+On Windows `pynput` has to be installed too.
 
 ## Documentation
 - [Documentation for pokete_classes](https://lxgr-linux.github.io/pokete/doc/pokete_classes/index.html)
@@ -133,12 +132,12 @@ On windows pynput has to be installed too.
 For release information see [Changelog](Changelog.md).
 
 ## Contributing
-Feel free to contribute what ever you want to this game.
+Feel free to contribute whatever you want to this game.
 New Pokete contributions are especially welcome, those are located in /pokete_data/poketes.py
 
-To see how to add more poketes/types/attacks to the game, see [the DevGuide](DevGuide.md)
+To learn how to add more poketes/types/attacks to the game, see [the development guide](DevGuide.md)
 
-After adding new Poketes and/or Attacks you may want to run
+After adding new Poketes and/or attacks you may want to run
 ```shell
 $ ./gen_wiki.py
 ```
@@ -151,5 +150,5 @@ Music:
 - Marllon Silva (xDeviruchi) - 8-bit-fantasy-adventure-music-pack - Available at [itch.io](https://xdeviruchi.itch.io/8-bit-fantasy-adventure-music-pack)
 - SketchyLogic - Map - Available at [opengameart.org](https://opengameart.org/content/nes-shooter-music-5-tracks-3-jingles)
 
-## Trouble shooting
+## Troubleshooting
 If you're experiencing problems on Japanese systems take a look at [this](https://gist.github.com/z80oolong/c7523367b798bdda094f859342f4c8be).

--- a/gen_wiki.py
+++ b/gen_wiki.py
@@ -26,11 +26,11 @@ class Wiki:
         """
         return f"""v{release.VERSION}
 
-# Pokete wiki
-This wiki/documentation is a compilation of all Poketes/attacks/types present in the Pokete game.
-This wiki can be generated using ```$ ./gen_wiki.py```.
+# Pokete Wiki
+This wiki/documentation is a compilation of all Poketes, attacks, and types present in the Pokete game.
+The wiki can be generated using ```$ ./gen_wiki.py```.
 
-Use ```$./gen_wiki.py help``` to get more information about different wikis.
+Use ```$ ./gen_wiki.py help``` to get more information about different wikis.
 
 You can find different versions of this wiki:
 


### PR DESCRIPTION
This PR fixes many English spelling and grammar mistakes in Markdown documentation.
Edited files: README.md, HowToPlay.md, DevGuide.md, and gen_wiki.py.

Some sentences were difficult to understand, so I tried my best to make them more clearer and understandable.