### PR TITLE
Release 0.8.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.8.2] - 2022-08-05
+
+Fixes a small bug in the representation of pokete on flathub.
+
 ## [0.8.1] - 2022-08-04
 
 The distribution size was shrinked extremely compared to 0.8.0

--- a/assets/pokete.metainfo.xml
+++ b/assets/pokete.metainfo.xml
@@ -37,6 +37,13 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release type="stable" version="0.8.2" date="2022-08-05" urgency="low">
+      <description>
+        <p>Version 0.8.2 fixes a display bug of the release notes on flatpak. Version 0.8.1 on the other hand brought the following improvements: This version brings a new cross-platform implementation of how the audio is played, written in go. This makes the installation size of pokete significantly smaller, as less dependencies are required. The first map has been reworked, to make it easier for new players to understand the game.</p>
+      </description>
+      <url>https://github.com/lxgr-linux/pokete/releases/tag/0.8.2</url>
+      <location>https://github.com/lxgr-linux/pokete/archive/refs/tags/0.8.2.tar.gz</location>
+    </release>
     <release type="stable" version="0.8.1" date="2022-08-04" urgency="high">
       <description>
         <p>This version brings a new cross-platform implementation of how the audio is played, written in go. This makes the installation size of pokete significantly smaller, as less dependencies are required. The first map has been reworked, to make it easier for new players to understand the game.</p>

--- a/assets/pokete.metainfo.xml
+++ b/assets/pokete.metainfo.xml
@@ -37,9 +37,16 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release type="stable" version="0.8.1" date="2022-08-04" urgency="high">
+      <description>
+        <p>This version brings a new cross-platform implementation of how the audio is played, written in go. This makes the installation size of pokete significantly smaller, as less dependencies are required. The first map has been reworked, to make it easier for new players to understand the game.</p>
+      </description>
+      <url>https://github.com/lxgr-linux/pokete/releases/tag/0.8.1</url>
+      <location>https://github.com/lxgr-linux/pokete/archive/refs/tags/0.8.1.tar.gz</location>
+    </release>
     <release type="stable" version="0.8.0" date="2022-07-25" urgency="medium">
       <description>
-              <p>We are constantly developing pokete further and with version 0.8.0 added a low of improvements and new features, such as music and sound effects. Running away from wild poketes can now fail and trainers can now have more than one pokete. Controls and hotkeys can now be remapped for different keyboard layouts. The default safe-file location has been moved to .local/share and some minor bugs have been fixed as well!</p>
+        <p>We are constantly developing pokete further and with version 0.8.0 added a low of improvements and new features, such as music and sound effects. Running away from wild poketes can now fail and trainers can now have more than one pokete. Controls and hotkeys can now be remapped for different keyboard layouts. The default safe-file location has been moved to .local/share and some minor bugs have been fixed as well!</p>
       </description>
       <url>https://github.com/lxgr-linux/pokete/releases/tag/0.8.0</url>
       <location>https://github.com/lxgr-linux/pokete/archive/refs/tags/0.8.0.tar.gz</location>


### PR DESCRIPTION
In Version 0.8.1 the release notes were forgotten in `assets/pokete.metainfo.xml`. Therefore, flatpak does not advise users to upgrade.