### PR TITLE
Set UTF-8 encoding to prevent encoding error on windows

### DIFF
--- a/gen_wiki.py
+++ b/gen_wiki.py
@@ -494,7 +494,7 @@ Those effects can be given to a Pokete through an attack.
         # writing to file
         if QUIET or VERBOSE:
             print("==> Writing to wiki.md...")
-        with open(filename, "w+") as file:
+        with open(filename, mode="w+", encoding="utf-8") as file:
             file.write(md_str)
 
     @staticmethod


### PR DESCRIPTION
Fix for error with encoding in gen_wiki.py