### PR TITLE
Update command.py

### DIFF
--- a/util/command/command.py
+++ b/util/command/command.py
@@ -34,34 +34,31 @@ class Command:
     @staticmethod
     def __line_setter(lines: list[tuple[str, str]], line_spaces: int):
         return "\n".join(
-            f"\t{line[0]}{" " * (line_spaces - len(line[0]))}{line[1]}" for line
-            in lines
+            f"\t{line[0]}{' ' * (line_spaces - len(line[0]))}{line[1]}" 
+            for line in lines
         )
 
     def __print_help(self, ex: str):
-        option_lines: list[tuple[str, str]] = [(command.name, command.desc) for
-                                               command in self.commands]
-        flag_lines: list[tuple[str, str]] = [
-            ("|".join(flag.aliases), flag.desc) for flag in self.flags]
-
-        line_spaces = sorted([
-            len(i[0]) for i in option_lines + flag_lines
-        ])[-1] + 8
-
-        print(f"""{self.name} -- {self.desc}
-
+        option_lines: list[tuple[str, str]] = [(command.name, command.desc) for command in self.commands]
+        flag_lines: list[tuple[str, str]] = [("|".join(flag.aliases), flag.desc) for flag in self.flags]
+        line_spaces = max((len(i[0]) for i in option_lines + flag_lines), default=0) + 8
+        options_section = (
+            f"Options:\n{self.__line_setter(option_lines, line_spaces)}"
+            if self.commands else ""
+        )
+        flags_section = (
+            f"Flags:\n{self.__line_setter(flag_lines, line_spaces)}"
+            if self.flags else ""
+        )
+        additional_info_section = f"\n{self.additional_info}\n" if self.additional_info else ""
+        print(
+            f"""{self.name} -- {self.desc}
 Usage:
     {ex}{f" {self.usage}" if self.usage else ""} <flags>
-{f"""
-Options:
-{self.__line_setter(option_lines, line_spaces)}
-""" if self.commands else ""}
-{f"""
-Flags:
-{self.__line_setter(flag_lines, line_spaces)}
-""" if self.flags else ""}
-{f"\n{self.additional_info}\n" if self.additional_info else ""}
-Copyright (c) lxgr-linux <lxgr-linux@protonmail.com> 2024""")
+{options_section}
+{flags_section}
+{additional_info_section}Copyright (c) lxgr-linux <lxgr-linux@protonmail.com> 2024"""
+        )
 
     def run(self, ex: str, options: list[str],
             flags: dict[str, list[str]]):


### PR DESCRIPTION
1. Error on Windows running pokete.py:

```
Traceback (most recent call last):
  File "C:\Users\Rob\Downloads\pokete\pokete.py", line 63, in <module>
    from util.command import RootCommand, Flag
  File "C:\Users\Rob\Downloads\pokete\util\command\__init__.py", line 1, in <module>
    from .command import Command, RootCommand, Flag
  File "C:\Users\Rob\Downloads\pokete\util\command\command.py", line 37
    f"\t{line[0]}{" " * (line_spaces - len(line[0]))}{line[1]}" for line
                                                                ^^^
SyntaxError: f-string: expecting '}'
```

Which can be fixed by the following:

```python
    @staticmethod
    def __line_setter(lines: list[tuple[str, str]], line_spaces: int):
        return "\n".join(
            f"\t{line[0]}{' ' * (line_spaces - len(line[0]))}{line[1]}" 
            for line in lines
        )
```

2. Error after applying the previous fix:

```
Traceback (most recent call last):
  File "C:\Users\Rob\Downloads\pokete\pokete.py", line 63, in <module>
    from util.command import RootCommand, Flag
  File "C:\Users\Rob\Downloads\pokete\util\command\__init__.py", line 1, in <module>
    from .command import Command, RootCommand, Flag
  File "C:\Users\Rob\Downloads\pokete\util\command\command.py", line 56
    Options:
    ^^^^^^^
SyntaxError: f-string: expecting '}'
```

Which can be fixed by the following:

```python
    def __print_help(self, ex: str):
        option_lines: list[tuple[str, str]] = [(command.name, command.desc) for command in self.commands]
        flag_lines: list[tuple[str, str]] = [("|".join(flag.aliases), flag.desc) for flag in self.flags]
        line_spaces = max((len(i[0]) for i in option_lines + flag_lines), default=0) + 8
        options_section = (
            f"Options:\n{self.__line_setter(option_lines, line_spaces)}"
            if self.commands else ""
        )
        flags_section = (
            f"Flags:\n{self.__line_setter(flag_lines, line_spaces)}"
            if self.flags else ""
        )
        additional_info_section = f"\n{self.additional_info}\n" if self.additional_info else ""
        print(
            f"""{self.name} -- {self.desc}
Usage:
    {ex}{f" {self.usage}" if self.usage else ""} <flags>
{options_section}
{flags_section}
{additional_info_section}Copyright (c) lxgr-linux <lxgr-linux@protonmail.com> 2024"""
        )
```

Fixed.