### PR TITLE
fix: correct typos and rename map change exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Since you're a Pokete Trainer, you can also fight against other trainers (they a
 with you when you get close enough to him. You can not run from a trainer fight; you either have to win, or lose. These
 trainer fights give double the XP.
 
-When one of your Poketes is too weak or dies, you can heal it by going into the Pokete Center (the house), talk the the
+When one of your Poketes is too weak or dies, you can heal it by going into the Pokete Center (the house), talk to the
 person there and choose the healing option.
 Here you can also take a look at all of your Poketes, and not just the six in your team. The ones marked with an `o` are
 the ones in your deck.

--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -19,8 +19,8 @@ needs to have this structure:
   # This is the Poketes simplified name/identifier without spaces and in lowercase, which is used to refer to the Pokete in the code
   "name": "Steini",  # This is the Pokete's pretty name
   "hp": 25,  # The Pokete's max health points
-  "atc": 2,  # The Pokete's attack points that will added to the Pokete's level
-  "defense": 4,  # The Pokete's defense points that will added to the Pokete's level
+  "atc": 2,  # The Pokete's attack points that will be added to the Pokete's level
+  "defense": 4,  # The Pokete's defense points that will be added to the Pokete's level
   "attacks": ["tackle", "politure", "brick_throw"],  # The Pokete's starting attacks
   "pool": [],  # List of additional ungeneric attacks the Pokete can learn
   "miss_chance": 0,  # The chance a Pokete will miss an attack, this is added to the attacks individual `miss_chance`
@@ -31,7 +31,7 @@ needs to have this structure:
   "evolve_poke": "",  # The name/identifier of the Pokete, that this Pokete evolves to at a certain level
   "evolve_lvl": 0,  # The level the Pokete evolves at
   "initiative": 5,
-  # The Pokete's initiative points that will added to the Pokete's level, and determine what Pokete starts in a fight
+  # The Pokete's initiative points that will be added to the Pokete's level, and determine what Pokete starts in a fight
   "ico": [{
     # A list of dictionaries containing a displayed string and a color; all those strings will be layered over each other and represent the Pokete in the fight
     "txt": """ +-------+
@@ -58,7 +58,7 @@ types.
 
 ## Adding attacks
 
-Every attack has an entry in the `attacks` dictionary in [`pokete_data/attacks.py `](./pokete_data/attacks.py). Every
+Every attack has an entry in the `attacks` dictionary in [`pokete_data/attacks.py`](./pokete_data/attacks.py). Every
 entry needs to have this structure:
 
 ```Python
@@ -91,7 +91,7 @@ be learned if the attack is in the Pokete's `"pool"` or `"attacks"` list.
 ### Effects
 
 The effect given in the `"effect"` attribute has to be the `c_name` of an effect listed
-in [`pokete_classes/types.py`](./pokete_classes/types.py ) or `None`.
+in [`pokete_classes/types.py`](./pokete_classes/types.py) or `None`.
 
 ### World action
 

--- a/docs/HowToPlay.md
+++ b/docs/HowToPlay.md
@@ -84,7 +84,7 @@ By going up to the person behind the counter you can interact with them.
 ![Center](https://raw.githubusercontent.com/lxgr-linux/pokete/master/assets/ss/ss14.png)
 
 ## Pokete shops
-In some towns there are also shops present where you can by items like Potions and Poketeballs.
+In some towns there are also shops present where you can buy items like Potions and Poketeballs.
 
 ![Shop](https://raw.githubusercontent.com/lxgr-linux/pokete/master/assets/ss/ss15.png)
 

--- a/mods/README.md
+++ b/mods/README.md
@@ -2,7 +2,7 @@
 
 ## Limitations
 The purpose and abilities of Mods are restricted to modifying the `pokete_data` module.
-But this can be very powerfull, because this enables adding and modifying Poketes, Maps, NPCs, trainers, types, achievements and much more.
+But this can be very powerful, because this enables adding and modifying Poketes, Maps, NPCs, trainers, types, achievements and much more.
 
 ## Structure
 The basic structure of a mod is:

--- a/src/pokete/__main__.py
+++ b/src/pokete/__main__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """This software is licensed under the GPL3
-You should have gotten an copy of the GPL3 license anlonside this software
+You should have gotten a copy of the GPL3 license alongside this software
 Feel free to contribute what ever you want to this game
 New Pokete contributions are especially welcome
-For this see the comments in the definations area
+For this see the comments in the definitions area
 You can contribute here: https://github.com/lxgr-linux/pokete
 Thanks to MaFeLP for your code review and your great feedback"""
 
@@ -39,7 +39,7 @@ from pokete.classes.audio import audio
 from pokete.classes.classes import PlayMap
 from pokete.classes.dex import PokeDex
 from pokete.classes.fight import ProtoFigure
-from pokete.classes.game import MapChangeExeption
+from pokete.classes.game import MapChangeException
 from pokete.classes.game_context import GameContext
 from pokete.classes.inv import inv
 from pokete.classes.landscape import MapInteract
@@ -233,7 +233,7 @@ def codes(string: str, figure: Figure):
 # main functions
 ################
 
-''' # this is awfull and has to be removed
+''' # this is awful and has to be removed
 def swap_poke(ctx: Context):
     """Trading with other players in the local network"""
     if not ask_bool(
@@ -288,7 +288,7 @@ def swap_poke(ctx: Context):
                                 "poke": figure.pokes[index].dict()})))
             data = sock.recv(1024)
             decode_data = json.loads(data.decode())
-    logging.info("[Swap_poke] Recieved %s", decode_data)
+    logging.info("[Swap_poke] Received %s", decode_data)
     mod_info = decode_data.get("mods", {})
     if loaded_mods.mod_info != mod_info:
         ask_ok(
@@ -510,7 +510,7 @@ def main():
         while True:
             try:
                 _game(game_map, figure)
-            except MapChangeExeption as err:
+            except MapChangeException as err:
                 game_map = err.map
 
 

--- a/src/pokete/classes/doors.py
+++ b/src/pokete/classes/doors.py
@@ -22,7 +22,7 @@ class CenterDoor(se.Object):
                if ob.map == obmp.ob_maps["centermap"]
                else ob.oldmap.shopdor.y + 1)
         ob.oldmap = obmp.ob_maps[i]
-        raise game.MapChangeExeption(ob.map)
+        raise game.MapChangeException(ob.map)
 
 
 class Door(se.Object):
@@ -37,7 +37,7 @@ class Door(se.Object):
         ob.add(obmp.ob_maps[self.arg_proto["map"]], self.arg_proto["x"],
                self.arg_proto["y"])
         ob.oldmap = obmp.ob_maps[i]
-        raise game.MapChangeExeption(obmp.ob_maps[self.arg_proto["map"]])
+        raise game.MapChangeException(obmp.ob_maps[self.arg_proto["map"]])
 
 
 class DoorToCenter(Door):

--- a/src/pokete/classes/game/__init__.py
+++ b/src/pokete/classes/game/__init__.py
@@ -1,1 +1,1 @@
-from .map_change_exception import MapChangeExeption
+from .map_change_exception import MapChangeException

--- a/src/pokete/classes/game/map_change_exception.py
+++ b/src/pokete/classes/game/map_change_exception.py
@@ -1,8 +1,8 @@
-"""Contains exception to exit a game loop and enter a new"""
+"""Contains exception to exit a game loop and enter a new one"""
 
 
-class MapChangeExeption(Exception):
-    """Exception to exit a game loop and enter a new
+class MapChangeException(Exception):
+    """Exception to exit a game loop and enter a new one
     ARGS:
         _map: The new map to enter"""
 

--- a/src/pokete/classes/multiplayer/connector.py
+++ b/src/pokete/classes/multiplayer/connector.py
@@ -1,4 +1,4 @@
-"""Contains class retaed to cennecting to a server"""
+"""Contains class related to connecting to a server"""
 
 from pokete import release
 from pokete.base.context import Context
@@ -17,7 +17,7 @@ DEFAULT_PORT = 9988
 
 
 class Connector:
-    """Managers server connection"""
+    """Manages server connection"""
 
     def __init__(self):
         self.host_port: HostPort = HostPort("localhost")
@@ -49,7 +49,7 @@ class Connector:
             ask_ok(ctx, f"Invalid Poke: {e.msg}")
 
     def set_host_port(self, ctx: Context):
-        """Asks the user for host and port to conenct to"""
+        """Asks the user for host and port to connect to"""
         while True:
             try:
                 self.host_port = HostPort.parse(
@@ -74,7 +74,7 @@ class Connector:
         self.user_name = ctx.figure.name
         self.user_name = ask_text(
             ctx,
-            ("That username isn't awailable right now\n" if reask else "")
+            ("That username isn't available right now\n" if reask else "")
             + "Please enter the username you want to use on the server",
             "Username:",
             self.user_name,
@@ -94,7 +94,7 @@ class Connector:
         except ConnectionException as excpt:
             ask_ok(
                 ctx,
-                f"An error occured connecting to {self.host_port} :\n{excpt}",
+                f"An error occurred connecting to {self.host_port} :\n{excpt}",
             )
             return False
         return True

--- a/src/pokete/classes/side_loops.py
+++ b/src/pokete/classes/side_loops.py
@@ -43,7 +43,7 @@ This  software is licensed under the GPL3, you should have gotten a \
 copy of the GPL3 license alongside this software.
 Feel  free to contribute what ever you want to this game, \
 new Pokete contributions are especially welcome.
-For  this see the comments in the definations area.
+For  this see the comments in the definitions area.
 You  can contribute here: https://github.com/lxgr-linux/pokete""",
                     60,
                     pre="",

--- a/src/pokete/data/__init__.py
+++ b/src/pokete/data/__init__.py
@@ -2,9 +2,9 @@
    p_data can be manipulated by mods and therefore should be injected and not
    imported
 
-   I know all this is very awfull...
+   I know all this is very awful...
 
-   ...not so awfull anymore, since I introduced code generation
+   ...not so awful anymore, since I introduced code generation
 """
 
 from .poketes import *


### PR DESCRIPTION
## Summary

- Fix various spelling/grammar issues in documentation and in-game text (README, docs, mods README, side loops).
- Correct typo in multiplayer connector messages and docstrings.
- Rename `MapChangeExeption` to `MapChangeException` and update all usages for consistency and readability.

## Details

- Updated user-facing text:
  - Fixed phrases like `talk the the`, `by items`, `powerfull`, and several comment/guide wording issues.
  - Clarified some docstrings and development guide comments (e.g. “will be added”).
- Code changes:
  - Renamed `MapChangeExeption` → `MapChangeException` in:
    - `src/pokete/classes/game/map_change_exception.py`
    - `src/pokete/classes/game/__init__.py`
    - `src/pokete/__main__.py`
    - `src/pokete/classes/doors.py`
  - Kept existing attack identifiers like `politure` / `chocer` unchanged to avoid breaking save data or protocol compatibility.

## Rationale

These changes improve readability and polish of both the player-facing text and the codebase, while keeping all identifiers and data structures that could affect compatibility intact.

## Testing

- Ran static checks on edited Python files (no new linter errors).
- Verified that all references to `MapChangeExeption` have been updated to `MapChangeException`.
- Basic import path sanity check for the renamed exception.