### PR TITLE
Add unit tests for battle damage calculation

### DIFF
--- a/src/pokete/classes/fight/attack_process.py
+++ b/src/pokete/classes/fight/attack_process.py
@@ -42,7 +42,7 @@ class AttackProcess:
             0
             if random_factor == 0
             else max(
-                3,
+                4,
                 round(
                     (attacker.atc * attack.factor / max(defender.defense, 1))
                     * random_factor

--- a/src/tests/pokete/fight/test_attack_process.py
+++ b/src/tests/pokete/fight/test_attack_process.py
@@ -1,0 +1,59 @@
+import os
+from types import SimpleNamespace
+
+# Prevent terminal-size crash during import on Windows/pytest
+os.get_terminal_size = lambda *args, **kwargs: os.terminal_size((80, 24))
+
+from pokete.classes.fight.attack_process import AttackProcess
+
+
+def make_attacker(atc: int):
+    return SimpleNamespace(atc=atc)
+
+
+def make_defender(defense: int):
+    return SimpleNamespace(defense=defense)
+
+
+def make_attack(factor: float):
+    return SimpleNamespace(factor=factor)
+
+
+def test_get_hp_returns_zero_on_miss():
+    attacker = make_attacker(10)
+    defender = make_defender(2)
+    attack = make_attack(1)
+
+    damage = AttackProcess.get_hp(attacker, defender, attack, random_factor=0, eff=1)
+
+    assert damage == 0
+
+
+def test_get_hp_has_minimum_damage_floor_of_4_on_hit():
+    attacker = make_attacker(2)
+    defender = make_defender(10)
+    attack = make_attack(1)
+
+    damage = AttackProcess.get_hp(attacker, defender, attack, random_factor=1, eff=1)
+
+    assert damage == 4
+
+
+def test_get_hp_keeps_higher_damage_values():
+    attacker = make_attacker(12)
+    defender = make_defender(2)
+    attack = make_attack(1)
+
+    damage = AttackProcess.get_hp(attacker, defender, attack, random_factor=1, eff=1)
+
+    assert damage == 6
+
+
+def test_get_hp_treats_zero_defense_as_one():
+    attacker = make_attacker(5)
+    defender = make_defender(0)
+    attack = make_attack(1)
+
+    damage = AttackProcess.get_hp(attacker, defender, attack, random_factor=1, eff=1)
+
+    assert damage == 5

--- a/src/tests/pokete/fight/test_attack_process.py
+++ b/src/tests/pokete/fight/test_attack_process.py
@@ -1,10 +1,55 @@
+import importlib.util
 import os
-from types import SimpleNamespace
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
-# Prevent terminal-size crash during import on Windows/pytest
+# Prevent terminal-size crash during import on Windows
 os.get_terminal_size = lambda *args, **kwargs: os.terminal_size((80, 24))
 
-from pokete.classes.fight.attack_process import AttackProcess
+
+def stub_module(name: str, **attrs):
+    mod = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[name] = mod
+    return mod
+
+
+# Stub the package structure needed for attack_process.py
+pokete_pkg = stub_module("pokete")
+pokete_pkg.__path__ = []
+
+classes_pkg = stub_module("pokete.classes")
+classes_pkg.__path__ = []
+
+fight_pkg = stub_module("pokete.classes.fight")
+fight_pkg.__path__ = []
+
+# Stub imported dependencies that get_hp does not actually need
+stub_module("pokete.classes.attack", Attack=type("Attack", (), {}))
+stub_module("pokete.release", SPEED_OF_TIME=1)
+stub_module("pokete.classes.fight.providers", Provider=type("Provider", (), {}))
+stub_module("pokete.classes.fight.fightmap", FightMap=type("FightMap", (), {}))
+stub_module("pokete.classes.attack_actions", AttackActions=type("AttackActions", (), {}))
+stub_module(
+    "pokete.classes.effects",
+    effects=SimpleNamespace(confusion=type("confusion", (), {})),
+)
+stub_module("pokete.classes.poke", Poke=type("Poke", (), {}))
+
+# Load only the attack_process.py module directly
+attack_process_path = Path("src/pokete/classes/fight/attack_process.py").resolve()
+spec = importlib.util.spec_from_file_location(
+    "pokete.classes.fight.attack_process",
+    attack_process_path,
+)
+attack_process_module = importlib.util.module_from_spec(spec)
+sys.modules["pokete.classes.fight.attack_process"] = attack_process_module
+spec.loader.exec_module(attack_process_module)
+
+AttackProcess = attack_process_module.AttackProcess
 
 
 def make_attacker(atc: int):
@@ -19,41 +64,51 @@ def make_attack(factor: float):
     return SimpleNamespace(factor=factor)
 
 
-def test_get_hp_returns_zero_on_miss():
-    attacker = make_attacker(10)
-    defender = make_defender(2)
-    attack = make_attack(1)
+class TestAttackProcess(unittest.TestCase):
+    def test_get_hp_returns_zero_on_miss(self):
+        attacker = make_attacker(10)
+        defender = make_defender(2)
+        attack = make_attack(1)
 
-    damage = AttackProcess.get_hp(attacker, defender, attack, random_factor=0, eff=1)
+        damage = AttackProcess.get_hp(
+            attacker, defender, attack, random_factor=0, eff=1
+        )
 
-    assert damage == 0
+        self.assertEqual(damage, 0)
+
+    def test_get_hp_has_minimum_damage_floor_of_4_on_hit(self):
+        attacker = make_attacker(2)
+        defender = make_defender(10)
+        attack = make_attack(1)
+
+        damage = AttackProcess.get_hp(
+            attacker, defender, attack, random_factor=1, eff=1
+        )
+
+        self.assertEqual(damage, 4)
+
+    def test_get_hp_keeps_higher_damage_values(self):
+        attacker = make_attacker(12)
+        defender = make_defender(2)
+        attack = make_attack(1)
+
+        damage = AttackProcess.get_hp(
+            attacker, defender, attack, random_factor=1, eff=1
+        )
+
+        self.assertEqual(damage, 6)
+
+    def test_get_hp_treats_zero_defense_as_one(self):
+        attacker = make_attacker(5)
+        defender = make_defender(0)
+        attack = make_attack(1)
+
+        damage = AttackProcess.get_hp(
+            attacker, defender, attack, random_factor=1, eff=1
+        )
+
+        self.assertEqual(damage, 5)
 
 
-def test_get_hp_has_minimum_damage_floor_of_4_on_hit():
-    attacker = make_attacker(2)
-    defender = make_defender(10)
-    attack = make_attack(1)
-
-    damage = AttackProcess.get_hp(attacker, defender, attack, random_factor=1, eff=1)
-
-    assert damage == 4
-
-
-def test_get_hp_keeps_higher_damage_values():
-    attacker = make_attacker(12)
-    defender = make_defender(2)
-    attack = make_attack(1)
-
-    damage = AttackProcess.get_hp(attacker, defender, attack, random_factor=1, eff=1)
-
-    assert damage == 6
-
-
-def test_get_hp_treats_zero_defense_as_one():
-    attacker = make_attacker(5)
-    defender = make_defender(0)
-    attack = make_attack(1)
-
-    damage = AttackProcess.get_hp(attacker, defender, attack, random_factor=1, eff=1)
-
-    assert damage == 5
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

This change continues work on Issue #197 by increasing battle damage so fights do not take as long.

## Changes made

* updated the `get_hp(...)` calculation in `src/pokete/classes/fight/attack_process.py`
* kept missed attacks at `0`
* added a minimum damage floor of `4` for landed attacks
* added unit tests for the damage calculation in `src/tests/pokete/fight/test_attack_process.py`

## Validation

* tested locally in battle
* confirmed battles felt noticeably faster
* added automated unit tests for `get_hp(...)`
* verified that 4 unit tests passed locally
