### PR TITLE
Improve menu accessibility and volume slider interaction

### DIFF
--- a/docs/HowToPlay.md
+++ b/docs/HowToPlay.md
@@ -28,7 +28,7 @@ After first starting the game you can move the character, the one little `a` on 
 
 ![Map](https://raw.githubusercontent.com/lxgr-linux/pokete/master/assets/ss/ss08.png)
 
-You can open the settings/menu by pressing `e`.
+You can open the settings/menu by pressing `2`.
 
 ![Menu](https://raw.githubusercontent.com/lxgr-linux/pokete/master/assets/ss/ss07.png)
 

--- a/src/pokete/__main__.py
+++ b/src/pokete/__main__.py
@@ -348,14 +348,14 @@ def _game(_map: PlayMap, figure: Figure):
     MapInteract.set_ctx(ctx)  # Npcs need this global context
     inp_dict: list[tuple[list[Action], tuple]] = [
         ([Action.DECK], (deck.deck, (ctx, 6, "Your deck"))),
-        ([Action.CANCEL, Action.EXIT_GAME], (quit, (ctx,))),
+        ([Action.MENU], (Menu(), (ctx,))),       
         ([Action.MAP], (roadmap.roadmap, (ctx,))),
         ([Action.INVENTORY], (inv, (ctx,))),
         ([Action.POKEDEX], (PokeDex(), (ctx,))),
         ([Action.CLOCK], (timer.clock, (ctx,))),
         ([Action.HELP], (Help(), (ctx,))),
         ([Action.INTERACT], (ContextMenu(), (ctx,))),
-        ([Action.MENU], (Menu(), (ctx,))),
+        ([Action.CANCEL, Action.EXIT_GAME], (quit, (ctx,))),
     ]
     inp_list = [i for j in inp_dict for i in j[0]]
     if _map.weather is not None:

--- a/src/pokete/base/input/hotkeys.py
+++ b/src/pokete/base/input/hotkeys.py
@@ -110,7 +110,7 @@ hotkey_mappings: dict[str, ActionList] = {
     "2": ActionList(
         [
             Action.ACT_2,
-            Action.EXIT_GAME,
+            Action.MENU,# Action.EXIT_GAME,
             Action.MOVE_POKETE,
             Action.NATURE_INFO,
             Action.RUN,
@@ -161,7 +161,7 @@ hotkey_mappings: dict[str, ActionList] = {
     "m": ActionList([Action.MAP, Action.MOVE_POKETE]),
     "c": ActionList([Action.CLOCK, Action.QUICK_ATC_3]),
     "?": ActionList([Action.HELP, Action.INFO]),
-    "e": ActionList([Action.MENU, Action.SCREEN_SWITCH]),
+    "e": ActionList([Action.SCREEN_SWITCH]),
     ":": ActionList([Action.CONSOLE]),
     "z": ActionList([Action.QUICK_ATC_1]),
     "x": ActionList([Action.QUICK_ATC_2]),

--- a/src/pokete/classes/menu.py
+++ b/src/pokete/classes/menu.py
@@ -5,6 +5,7 @@ from typing import Never, Optional
 import scrap_engine as se
 
 from pokete.base.context import Context
+from pokete.base.ui.elements.labels import CloseLabel
 from pokete.base.ui.notify import notifier
 from pokete.base.ui.views.boxes import InfoBoxView
 from pokete.base.ui.views.choose_box import ChooseBoxView
@@ -21,7 +22,7 @@ from .side_loops import About
 
 class Menu(ChooseBoxView):
     def __init__(self):
-        super().__init__(50, 35, "Menu")
+        super().__init__(50, 35, "Menu", [CloseLabel(),])
         self.playername_input = TextInputBox("Playername:", 17)
         self.represent_char_input = TextInputBox("Char:", 1)
         self.mods_label = se.Text("Mods", state="float")

--- a/src/pokete/classes/movemap.py
+++ b/src/pokete/classes/movemap.py
@@ -38,7 +38,7 @@ class Movemap(GameSubmap, Overview, MouseInteractor):
         self.label_bg = se.Square(" ", self.width, 1, state="float")
         self.labels: list[HightlightableText] = [
             HightlightableText(f"{Action.DECK.mapping}: Deck"),
-            HightlightableText(f"{Action.EXIT_GAME.mapping}: Quit"),
+            HightlightableText(f"{Action.MENU.mapping}: Menu"),
             HightlightableText(f"{Action.MAP.mapping}: Map"),
             HightlightableText(f"{Action.INVENTORY.mapping}: Inv."),
             HightlightableText(f"{Action.POKEDEX.mapping}: Dex"),

--- a/src/pokete/classes/settings.py
+++ b/src/pokete/classes/settings.py
@@ -116,6 +116,9 @@ class Slider(se.Box, Overview, MouseInteractor):
                 if event.pressed:
                     self.set_slider(area_idx)
                     self.__set_setting()
+            elif event.type == MouseEventType.DRAG_LEFT:
+                self.set_slider(area_idx)
+                self.__set_setting()
 
     def change(self, ctx: Context):
         """Changes the current position by a value
@@ -124,7 +127,7 @@ class Slider(se.Box, Overview, MouseInteractor):
         self.overview = ctx.overview
         ctx = change_ctx(ctx, self)
         while True:
-            action, _ = get_action()
+            action, _ = get_action()          
             if (strength := action.get_x_strength()) != 0:
                 if 0 <= (self.offset + strength) <= self.boundary:
                     self.set_slider(self.offset + strength)

--- a/src/pokete/classes/side_loops.py
+++ b/src/pokete/classes/side_loops.py
@@ -62,7 +62,6 @@ class Help(LoopBox):
                 """Controls:
 'w':up, 'a':left,
 's':down, 'd':right,
-'e':menu
 
 When walking into the high grass (';') you may get attacked
 by wild Poketes, those can be killed or weakened and caught.


### PR DESCRIPTION
This change updates the menu hotkey from `e` to `2`, removes the old in game help hint about opening the menu with `e`, and updates the docs to reflect opening the menu with `2`. It also adds the missing `q: close` hint to the menu box and updates the volume slider so it can be adjusted by dragging left or right instead of only clicking a position.

**Why this change**

- The new menu shortcut makes the menu easier for players to find and open, especially since it also contains the option to exit the game. Additionally, the previous quit shortcut on `2` was kind of redundant because quitting is already accessible via `q`, so reassigning `2` to open the menu makes better use of the key.

**Summary**
- Changed the menu open hotkey from `e` to `2`.
- Removed the old help hint for opening the menu with `e`.
- Updated the docs to say the menu opens with `2`.
- Added the missing `q: close` label on the menu box.
- Updated the volume slider to support dragging.